### PR TITLE
Animation probabilities are incorrectly skewed

### DIFF
--- a/src/dotNet/Animations.cs
+++ b/src/dotNet/Animations.cs
@@ -760,7 +760,7 @@ namespace DesktopPet
 
                     iRandMax += anim.Probability;
                 }
-                iVal = rand.Next(0, iRandMax);
+                iVal = rand.Next(1, iRandMax+1);
                 foreach (TNextAnimation anim in list)
                 {
                     if (anim.only != TNextAnimation.TOnly.NONE && (anim.only & where) == 0) continue;


### PR DESCRIPTION
Note: I don't actually have the means to compile and test this fix. I'm running purely on intuition.

### Issue
I was using probabilities close to 1, and the result felt oddly skewed, so I made a pet specifically for testing this :
[Blue Dice.xml](https://github.com/Adrianotiger/desktopPet/files/7313164/Blue.Dice.zip)

The pet spawns as a blue square. Every second, it (should) have a 50% chance to either shortly flash white, or turn red until manually reset.

I spawned the maximum amount of pets, and split them in two groups, one where the probability is encoded as `1:1`, one where it is encoded as `2:2`. (A pet's group can be re-rolled by clicking on it. It will display the group it belongs to.)

The pets from the `2:2` group will all quickly turn red. Yet I have never seen a pet from the `1:1` group ever turn red.

### Diagnostic
I believe the issue comes from [Animation.cs line 763](https://github.com/Adrianotiger/desktopPet/blob/261e9d26251f2c871cacb0e05007f5db9d5d6df7/src/dotNet/Animations.cs#L763) :
```cs
iVal = rand.Next(0, iRandMax);
foreach (TNextAnimation anim in list)
{
    iSum += anim.Probability;
    if (iSum >= iVal)
    {
        iDefaultID = anim.ID;
        break;
    }
}
```
For pets in the `1:1` group, turning red requires `iVal == 2`.
However, the current code would run `rand.Next(0, 2)`, which can only return `0` or `1`. Thus they can never turn red.

For pets in the `2:2` group, turning red requires ` iVal >= 3`.
`rand.Next(0, 4)` can only return `0`, `1`, `2`, `3`, thus the probalities are skewed into 75% flashing, and 25% turning red.

Effectively, the first animation  in the list has its weight increased by one, and the last animation on the list has its weight decreased by one.

This is fixed by offsetting both parameters by 1 :

```cs
iVal = rand.Next(1, iRandMax + 1);
```