### PR TITLE
Use non-locking method to open image

### DIFF
--- a/Tools/PetEditor/EditWindows.cs
+++ b/Tools/PetEditor/EditWindows.cs
@@ -200,7 +200,7 @@ namespace PetEditor
                 image.BackgroundImageChanged += (s, e) =>
                 {
                     var stream = new MemoryStream();
-                    image.Image.Save(stream, image.Image.RawFormat);
+                    image.Image.Save(stream, System.Drawing.Imaging.ImageFormat.Png);
                     var bytes = stream.ToArray();
                     Program.AnimationXML.Image.Png = Convert.ToBase64String(bytes);
                     DrawLinesOnPictures(pictureBox1, image.Image, Program.AnimationXML.Image.TilesX, Program.AnimationXML.Image.TilesY);
@@ -1061,7 +1061,9 @@ namespace PetEditor
                 openFileDialog.Filter = "Image (*.png, *.ico)|*.png;*.ico|All files (*.*)|*.*";
                 if (openFileDialog.ShowDialog(this) == DialogResult.OK)
                 {
-                    t.Image = Image.FromFile(openFileDialog.FileName);
+                    using (Bitmap bmp = new Bitmap(openFileDialog.FileName))
+                        t.Image = new Bitmap(bmp);
+
                     t.BackgroundImage = t.Image;
                 }
             };

--- a/Tools/PetEditor/XmlTools.cs
+++ b/Tools/PetEditor/XmlTools.cs
@@ -93,9 +93,6 @@ namespace PetEditor
             int h = Math.Min(256, (int)(img.PhysicalDimension.Height / TilesY));
             AnimationImages.ImageSize = new Size(w, h);
             AnimationIcons.ImageSize = new Size(32, 32);
-
-            var stream = new MemoryStream();
-            img.Save(stream, img.RawFormat);
             
             for (var y = 0; y < TilesY; y++)
             {


### PR DESCRIPTION
The current method for loading an image locks the file until a different image is loaded or the pet editor is restarted.
This is disruptive to the workflow because it is not possible to edit and save a sprite sheet while the image is loaded, 

The new method releases the file once it has been loaded into memory.
I think this will be okay because the program doesn't need to save changes to the image.